### PR TITLE
Fixed manpages-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can access the Windows C drive from WSL as ```/mnt/c```
 
 #### Basic Linux Programming Setup
 
-```apt install gcc manpage-dev vim git make```
+```apt install gcc manpages-dev vim git make```
 
 #### Basic Linux Kernel Programming Setup
 


### PR DESCRIPTION
The debian installation guide has an error with the package name. It's manpages-dev not manpage-dev.